### PR TITLE
[bug #164001976] fixed the update error for the patch route

### DIFF
--- a/server/route/route.js
+++ b/server/route/route.js
@@ -185,26 +185,24 @@ export const getOffice = (req, res) => {
 
 export const editOffice = (req, res) => {
   const { id } = req.params;
-  const oldData = Offices;
-  const newData = [];
-  const office = req.body;
-  office.id = Number(id);
-  newData.push(office);
-  const editedOffice = oldData.map(obj => newData.find(o => o.id === obj.id));
-  if (editedOffice.length === 0) {
+  const rqOffice = Offices.find(o => o.id === Number(id));
+  if (rqOffice === undefined) {
     res.json({
       status: 404,
       message: 'There is no office with the specified ID',
     });
   } else {
     const response = isMissingValue(req.body);
-    if (ifOfficeExist(req.body, Parties)) {
+    if (ifOfficeExist(req.body, Offices)) {
       res.status(200).json({ status: 200, message: 'The office already exists' });
     } else if (!response) {
+      if (req.body.name) { rqOffice.name = req.body.name; }
+      if (req.body.type) { rqOffice.type = req.body.type; }
+
       res.json({
         status: 200,
         message: 'The data has been succefully edited',
-        data: editedOffice,
+        data: req.body,
       });
     } else {
       res.json({

--- a/server/tests/patch-office.test.js
+++ b/server/tests/patch-office.test.js
@@ -3,7 +3,7 @@
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 import { app } from '../server';
-import { Offices } from './../route/route';
+import { Offices } from '../route/route';
 
 chai.use(require('chai-like'));
 chai.use(require('chai-things'));
@@ -60,8 +60,7 @@ describe('PATCH /offices/:id', () => {
         expect(status).to.equal(200);
         expect(body.status).to.equal(200);
         expect(body.data)
-          .to.be.an('array')
-          .that.contains.something.like({ name: 'dmo' });
+          .to.be.an('object').have.property('name').eql('dmo');
         done();
       });
   });


### PR DESCRIPTION
#### What does this PR do?
Enables the server to receive a patch request from the user and patch the data and update the data array.

#### Description of Task to be completed?
The data is received from the user checked for errors and if it's good the required data to be patched is found and patched. once patched the data is stored on the data array

#### How should this be manually tested?
* Clone the repo to your local machine
* Run `npm install` to install the dependencies
* Once its done `cd` into the project
* From the terminal run `babel-node server/server.js`
* Open postman and test the PATCH `/parties/:id` route

#### Any background context you want to provide?
Before the update, the server was unable to store the changes to the data array

#### What are the relevant pivotal tracker stories?
#164001976