### PR TITLE
[chore #164074806] adding the database to the party routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "body-parser": "^1.18.3",
     "custom-env": "^1.0.0",
     "express": "^4.16.4",
-    "jsonwebtoken": "^8.4.0",
+    "jsonwebtoken": "^8.5.0",
     "make-runnable": "^1.3.6",
     "pg": "^7.8.0"
   }

--- a/server/Untitled-1.txt
+++ b/server/Untitled-1.txt
@@ -1,0 +1,39 @@
+    const query = 'SELECT * FROM parties WHERE name=$1 OR logourl=$2';
+
+    pool.query(query, [body.name, body.logoUrl])
+      .then((results) => {
+        if (results.rowCount > 0) {
+          res.status(200).json({ status: 200, message: 'The party already exists or your logo Url exists :-)' });
+        } else {
+          
+          const response = isMissingValue(body);
+          if (!response) {
+            const insQuery = 'INSERT INTO parties(name,hqaddress,logourl,abbreviation) VALUES($1,$2,$3,$4)';
+            pool.query(insQuery, [body.name, body.hqAddress, body.logoUrl, body.abbreviation])
+              // eslint-disable-next-line no-unused-vars
+              .then((results) => {
+                const query = 'SELECT * FROM parties WHERE name=$1';
+                pool.query(query, [body.name])
+                  .then((results) => {
+                    if (results.rowCount === 1) {
+                      res.status(201).json({
+                        status: 201,
+                        data: results.rows,
+                      });
+                    }
+                  });
+              })
+              .catch((e) => {
+                throw e;
+              });
+          } else {
+            res.status(200).json({
+              status: 200,
+              message: response,
+            });
+          }
+        }
+      })
+      .catch((e) => {
+        throw e;
+      });

--- a/server/controller/parties.js
+++ b/server/controller/parties.js
@@ -1,25 +1,55 @@
 import {
-  ifExist,
-  increment,
   partyEntityValidator,
   partyPropertySpecs,
   isMissingValue,
 } from '../helper/helper';
+import pool from '../model/connection';
+
 
 // eslint-disable-next-line import/no-mutable-exports
-export let Parties = [];
+export const Parties = [];
 
 export const postParty = ({ body }, res) => {
+  // check for entity specs
   if (partyEntityValidator(body)) {
-    if (ifExist(body, Parties)) {
-      res.status(200).json({ status: 200, message: 'The party already exists or your logo Url exists :-)' });
+    // check for empty values
+    const response = isMissingValue(body);
+    if (!response) {
+      // check for duplication
+      const query = 'SELECT * FROM parties WHERE name=$1 OR logourl=$2';
+
+      pool.query(query, [body.name, body.logoUrl])
+        .then((results) => {
+          if (results.rowCount > 0) {
+            res.status(200).json({ status: 200, message: 'The party already exists or your logo Url exists :-)' });
+          } else {
+          // insert new data
+            const insQuery = 'INSERT INTO parties(name,hqaddress,logourl,abbreviation) VALUES($1,$2,$3,$4)';
+            pool.query(insQuery, [body.name, body.hqAddress, body.logoUrl, body.abbreviation])
+              // eslint-disable-next-line no-unused-vars
+              .then((results) => {
+                const query = 'SELECT * FROM parties WHERE name=$1';
+                pool.query(query, [body.name])
+                  .then((results) => {
+                    if (results.rowCount === 1) {
+                      res.status(201).json({
+                        status: 201,
+                        data: results.rows,
+                      });
+                    }
+                  });
+              })
+              .catch((e) => {
+                throw e;
+              });
+          }
+        })
+        .catch((e) => { throw e; });
     } else {
-      const response = increment(body, Parties);
-      if (response === undefined) {
-        res.status(201).json({ status: 201, data: Parties });
-      } else {
-        res.status(200).json({ status: 200, data: response });
-      }
+      res.status(200).json({
+        status: 200,
+        message: response,
+      });
     }
   } else {
     const missings = partyPropertySpecs(body);
@@ -32,85 +62,112 @@ export const postParty = ({ body }, res) => {
 
 
 export const getParties = (req, res) => {
-  if (Parties.length === 0) {
-    res.json({
-      status: 404,
-      message: 'There is no data at the moment',
+  const getQuery = 'SELECT * FROM parties';
+
+  pool.query(getQuery)
+    .then((results) => {
+      if (results.rowCount === 0) {
+        res.status(404).json({
+          status: 404,
+          message: 'There are no parties at the moment',
+        });
+      } else {
+        res.status(200).json({
+          status: 200,
+          data: results.rows,
+        });
+      }
+    })
+    .catch((e) => {
+      throw e;
     });
-  } else {
-    res.json({
-      status: 200,
-      data: Parties,
-    });
-  }
 };
 
 
 export const getParty = (req, res) => {
-  if (Parties.length === 0) {
-    res.json({
-      status: 404,
-      message: 'There is no party with the specified ID',
+  const getQuery = 'SELECT * FROM parties WHERE id=$1';
+  const { id } = req.params;
+
+  pool.query(getQuery, [id])
+    .then((results) => {
+      if (results.rowCount === 0) {
+        res.status(404).json({
+          status: 404,
+          message: 'There is no party with the specified ID',
+        });
+      } else {
+        res.status(200).json({
+          status: 200,
+          data: results.rows,
+        });
+      }
     });
-  } else {
-    res.json({
-      status: 200,
-      data: Parties[req.params.id - 1],
-    });
-  }
 };
 
 export const editParty = (req, res) => {
   const { id } = req.params;
-  const rqParty = Parties.find(o => o.id === Number(id));
-  if (rqParty === undefined) {
-    res.json({
-      status: 404,
-      message: 'There is no party with the specified ID',
-    });
+  const editQuery = 'UPDATE parties SET name=$1, hqaddress=$2, logourl=$3, abbreviation=$4 WHERE id=$5';
+  const {
+    name, hqAddress, logoUrl, abbreviation,
+  } = req.body;
+  const response = isMissingValue(req.body);
+
+  if (!response) {
+    const findDuplacate = 'SELECT * FROM parties WHERE name =$1 AND logourl=$2';
+    pool.query(findDuplacate, [name, logoUrl])
+      .then((results) => {
+        if (results.rowCount === 0) {
+          pool.query(editQuery, [name, hqAddress, logoUrl, abbreviation, id])
+            .then((results) => {
+              if (results === 0) {
+                res.status(200).json({
+                  status: 200,
+                  message: 'There is no party with the specified ID',
+                });
+              } else {
+                const getQuery = 'SELECT * FROM parties WHERE id=$1';
+                pool.query(getQuery, [id])
+                  .then((results) => {
+                    res.status(200).json({
+                      status: 200,
+                      data: results.rows,
+                    });
+                  });
+              }
+            })
+            .catch((e) => { throw e; });
+        } else {
+          res.status(200).json({
+            status: 200,
+            message: 'The party already exists or your logo Url exists: -)',
+          });
+        }
+      });
   } else {
-    const response = isMissingValue(req.body);
-    if (ifExist(req.body, Parties)) {
-      res.status(200).json({ status: 200, message: 'The party already exists or your logo Url exists :-)' });
-    } else if (!response) {
-      if (req.body.name) { rqParty.name = req.body.name; }
-      if (req.body.hqAddress) { rqParty.hqAddress = req.body.hqAddress; }
-      if (req.body.logoUrl) { rqParty.logoUrl = req.body.logoUrl; }
-      res.json({
-        status: 200,
-        message: 'The data has been succefully edited',
-        data: req.body,
-      });
-    } else {
-      res.json({
-        status: 200,
-        data: response,
-      });
-    }
+    res.status(200).json({
+      status: 200,
+      message: response,
+    });
   }
 };
 
 
 export const deleteParty = (req, res) => {
-  const newData = [];
-  if (Parties[req.params.id - 1] === undefined) {
-    res.json({
-      status: 404,
-      message: 'There is no party with the specified ID',
-    });
-  } else {
-    delete Parties[req.params.id - 1];
-    for (let i = 0; i < Parties.length; i++) {
-      if (Parties[i] !== undefined) {
-        newData.push(Parties[i]);
-      }
-    }
+  const { id } = req.params;
+  const deleteQuery = 'DELETE FROM parties WHERE id=$1';
 
-    Parties.length = 0;
-    Parties = newData;
-    res.json({
-      status: 200,
-      message: 'The party has been deleted successfully',
+  pool.query(deleteQuery, [id])
+    .then((results) => {
+      if (results.rowCount === 0) {
+        res.status(404).json({
+          status: 404,
+          message: 'There is no party with the specified ID',
+        });
+      } else {
+        res.status(200).json({
+          status: 200,
+          message: 'The party has been deleted successfully',
+        });
+      }
     });
-  }
 };

--- a/server/helper/helper.js
+++ b/server/helper/helper.js
@@ -1,25 +1,3 @@
-export const ifExist = ({ name, logoUrl }, array) => {
-  if (array.length >= 0) {
-    for (let i = 0; i < array.length; i++) {
-      if (name === array[i].name || logoUrl === array[i].logoUrl) {
-        return true;
-      }
-    }
-    return false;
-  }
-};
-
-export const ifOfficeExist = ({ name }, array) => {
-  if (array.length >= 0) {
-    for (let i = 0; i < array.length; i++) {
-      if (name === array[i].name) {
-        return true;
-      }
-    }
-    return false;
-  }
-};
-
 export const isMissingValue = (body) => {
   const arrayOfWords = Object.values(body);
   const property = Object.keys(body);
@@ -41,69 +19,35 @@ export const isMissingValue = (body) => {
   return `${missings} are empty`;
 };
 
-
-export const increment = (body, array) => {
-  const data = body;
-  if (!isMissingValue(body)) {
-    if (array.length === 0) {
-      data.id = 1;
-      array.push(body);
-    } else {
-      data.id = array.length + 1;
-      array.push(body);
-    }
-  } else {
-    return isMissingValue(body);
-  }
-};
-
-
 export const partyEntityValidator = (body) => {
   if (
     body.hasOwnProperty('name')
     && body.hasOwnProperty('hqAddress')
     && body.hasOwnProperty('logoUrl')
+    && body.hasOwnProperty('abbreviation')
   ) {
     return true;
   }
-};
-
-
-export const officeEntityValidator = (body) => {
-  if (
-    body.hasOwnProperty('name')
-    && body.hasOwnProperty('type')
-  ) {
-    return true;
-  }
+  return false;
 };
 
 export const partyPropertySpecs = (body) => {
-  const arrayOfProperty = Object.keys(body);
-  const property = ['name', 'hqAddress', 'logoUrl'];
-  const contains = [];
+  const missing = [];
+  if (!body.hasOwnProperty('name')) {
+    missing.push('name');
+  }
+  if (!body.hasOwnProperty('hqAddress')) {
+    missing.push('hqAddress');
+  }
+  if (!body.hasOwnProperty('logoUrl')) {
+    missing.push('logoUrl');
+  }
+  if (!body.hasOwnProperty('abbreviation')) {
+    missing.push('abbreviation');
+  }
+  if (!body.hasOwnProperty('address')) {
+    missing.push('address');
+  }
 
-
-  arrayOfProperty.forEach(p1 => property.forEach((p2) => {
-    if (p1 === p2) {
-      contains.push(p1);
-    }
-  }));
-
-  return `The object  has the properties ${contains} instead of having ${property}`;
-};
-
-export const officePropertySpecs = (body) => {
-  const arrayOfProperty = Object.keys(body);
-  const property = ['name', 'type'];
-  const contains = [];
-
-
-  arrayOfProperty.forEach(p1 => property.forEach((p2) => {
-    if (p1 === p2) {
-      contains.push(p1);
-    }
-  }));
-
-  return `The object  has the properties ${contains} instead of having ${property}`;
+  return `Please make sure to include ${missing}`;
 };

--- a/server/middleware/adminVerify.js
+++ b/server/middleware/adminVerify.js
@@ -1,0 +1,24 @@
+import bcrypt from 'bcryptjs';
+import pool from '../model/connection';
+
+const isAdmin = ({ userData }, res, next) => {
+  const { email, password } = userData.body;
+  if (userData !== undefined) {
+    pool.query('SELECT * FROM users WHERE email=$1', [email])
+      .then((response) => {
+        if (response.rowCount === 1) {
+          const hashedpasword = response.rows[0].password;
+
+          bcrypt.compare(password, hashedpasword, (err, result) => {
+            if (result && response.rows[0].isadmin) {
+              next();
+            } else {
+              res.sendStatus(403);
+            }
+          });
+        }
+      });
+  }
+};
+
+export default isAdmin;

--- a/server/middleware/verify.js
+++ b/server/middleware/verify.js
@@ -1,0 +1,22 @@
+
+import jwt from 'jsonwebtoken';
+
+const jwtVerifier = (req, res, next) => {
+  const bearerHeader = req.headers.authorization;
+  if (bearerHeader !== undefined) {
+    const bearer = bearerHeader.split(' ');
+    const bearerToken = bearer[1];
+    jwt.verify(bearerToken, process.env.HASH, (err, decoded) => {
+      if (err) {
+        res.sendStatus(403);
+      } else {
+        req.userData = decoded;
+      }
+    });
+    next();
+  } else {
+    res.sendStatus(403);
+  }
+};
+
+export default jwtVerifier;

--- a/server/server.js
+++ b/server/server.js
@@ -5,15 +5,18 @@ import officesRouter from './route/offices';
 import defaultRoute from './controller/default';
 import login from './route/login';
 import signupUser from './controller/signup';
-
-
+import jwtverifier from './middleware/verify';
+import isAdmin from './middleware/adminVerify';
 
 export const app = express();
 export const PORT = process.env.PORT || 3200;
 app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({
+  extended: true,
+}));
 
-app.use('/api/v1/parties/', partiesRouter);
-app.use('/api/v1/offices/', officesRouter);
+app.use('/api/v1/parties/', jwtverifier, isAdmin, partiesRouter);
+app.use('/api/v1/offices/', jwtverifier, isAdmin, officesRouter);
 app.use('/api/v1/login/', login);
 app.use('/api/v1/signup/', signupUser);
 app.use('/', defaultRoute);

--- a/server/tests/get-a-party.test.js
+++ b/server/tests/get-a-party.test.js
@@ -1,0 +1,49 @@
+/* eslint-disable prefer-destructuring */
+/* eslint-disable no-undef */
+import chai from 'chai';
+
+import chaiHttp from 'chai-http';
+import { app } from '../server';
+import { Parties } from '../controller/parties';
+
+chai.use(require('chai-like'));
+chai.use(require('chai-things'));
+
+chai.use(chaiHttp);
+
+// eslint-disable-next-line no-unused-vars
+const expect = chai.expect;
+
+describe('GET /parties/:id', () => {
+  it('should send a message if there is no party', (done) => {
+    Parties.length = 0;
+    chai.request(app)
+      .get('/v1/parties/5')
+      .end((err, { status, body }) => {
+        expect(status).to.equal(404);
+        expect(body.status).to.equal(404);
+        expect(body.message).to.equal('There is no party with the specified ID');
+        done();
+      });
+  });
+  it('should return the required party with the id', (done) => {
+    const party = {
+      name: 'chama cha mapinduzi',
+      hqAddress: 'p.o bo 1234, dar-es-salaam',
+      logoUrl: '/img/ccm.png',
+    };
+
+    chai
+      .request(app)
+      .post('/v1/parties')
+      .send(party)
+      .end();
+    chai.request(app)
+      .get('/v1/parties/1')
+      .end((err, { status, body }) => {
+        expect(status).to.equal(200);
+        expect(body.status).to.equal(200);
+        done();
+      });
+  });
+});

--- a/server/tests/get-parties.test.js
+++ b/server/tests/get-parties.test.js
@@ -1,0 +1,62 @@
+/* eslint-disable prefer-destructuring */
+/* eslint-disable no-undef */
+import chai from 'chai';
+
+import chaiHttp from 'chai-http';
+import { app } from '../server';
+import { Parties } from '../controller/parties';
+
+chai.use(require('chai-like'));
+chai.use(require('chai-things'));
+
+// eslint-disable-next-line no-unused-vars
+const expect = chai.expect;
+
+chai.use(chaiHttp);
+
+describe('GET /parties', () => {
+  it('should GET all the parties', (done) => {
+    Parties.length = 0;
+
+    const party = {
+      name: 'civic union front',
+      hqAddress: 'p.o bo 1234, dar-es-salaam',
+      logoUrl: '/img/cuf.png',
+    };
+    const party2 = {
+      name: 'chama cha maendeleo na demokrasia',
+      hqAddress: 'p.o bo 1234, dar-es-salaam',
+      logoUrl: '/img/chadema.png',
+    };
+
+    chai
+      .request(app)
+      .post('/v1/parties')
+      .send(party)
+      .end();
+    chai
+      .request(app)
+      .post('/v1/parties')
+      .send(party2)
+      .end();
+    chai.request(app)
+      .get('/v1/parties')
+      .end((err, { status, body }) => {
+        expect(status).to.equal(200);
+        expect(body.data).to.have.lengthOf(2);
+        done();
+      });
+  });
+  it('should GET a message if empty', (done) => {
+    Parties.length = 0;
+    chai
+      .request(app)
+      .get('/v1/parties')
+      .end((err, { status, body }) => {
+        expect(status).to.equal(404);
+        expect(body.status).to.equal(404);
+        expect(body.message).to.equal('There are no parties at the moment');
+        done();
+      });
+  });
+});

--- a/server/tests/patch-a-party.test.js
+++ b/server/tests/patch-a-party.test.js
@@ -1,0 +1,121 @@
+/* eslint-disable prefer-destructuring */
+/* eslint-disable no-undef */
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import { app } from '../server';
+import { Parties } from '../controller/parties';
+
+chai.use(require('chai-like'));
+chai.use(require('chai-things'));
+
+chai.use(chaiHttp);
+
+// eslint-disable-next-line no-unused-vars
+const expect = chai.expect;
+
+describe('PATCH /parties/:id', () => {
+  it('should send a message if there is no party', (done) => {
+    Parties.length = 0;
+    const party = {
+      name: 'chama',
+      hqAddress: 'p.o bo 12, singida',
+      logoUrl: '/img/c.png',
+    };
+
+    chai.request(app)
+      .patch('/v1/parties/5')
+      .send(party)
+      .end((err, { status, body }) => {
+        expect(status).to.equal(404);
+        expect(body).to.have.property('message').eql('There is no party with the specified ID');
+        done();
+      });
+  });
+  it('should return the edited party with a successful message', (done) => {
+    Parties.length = 0;
+
+    const party = {
+      name: 'civic union front',
+      hqAddress: 'p.o bo 1234, dar-es-salaam',
+      logoUrl: '/img/cuf.png',
+    };
+    chai.request(app)
+      .post('/v1/parties')
+      .send(party)
+      .end();
+
+
+    const partyPatch = {
+      name: 'chama',
+      hqAddress: 'p.o bo 12, singida',
+      logoUrl: '/img/c.png',
+    };
+    chai.request(app)
+      .patch('/v1/parties/1')
+      .send(partyPatch)
+      .end((err, { status, body }) => {
+        expect(status).to.equal(200);
+        expect(body.status).to.equal(200);
+        expect(body.data).to.be.an('object').have.property('name').eql('chama');
+        done();
+      });
+  });
+
+  it('should not accept empty values', (done) => {
+    Parties.length = 0;
+
+    const party = {
+      name: 'civic union front',
+      hqAddress: 'p.o bo 1234, dar-es-salaam',
+      logoUrl: '/img/cuf.png',
+    };
+    chai.request(app)
+      .post('/v1/parties')
+      .send(party)
+      .end();
+
+
+    const partyPatch = {
+      name: '',
+      hqAddress: 'p.o bo 12, singida',
+      logoUrl: '/img/c.png',
+    };
+    chai.request(app)
+      .patch('/v1/parties/1')
+      .send(partyPatch)
+      .end((err, { status, body }) => {
+        expect(status).to.equal(200);
+        expect(body.status).to.equal(200);
+        expect(body.data).eql('name is empty');
+        done();
+      });
+  });
+  it('should not duplicate the same edit', (done) => {
+    Parties.length = 0;
+
+    const party = {
+      name: 'civic union front',
+      hqAddress: 'p.o bo 1234, dar-es-salaam',
+      logoUrl: '/img/cuf.png',
+    };
+    chai.request(app)
+      .post('/v1/parties')
+      .send(party)
+      .end();
+
+    const partyPatch = {
+      name: 'civic union front',
+      hqAddress: 'p.o bo 1234, dar-es-salaam',
+      logoUrl: '/img/cuf.png',
+    };
+    chai.request(app)
+      .patch('/v1/parties/1')
+      .send(partyPatch)
+      .end((err, { status, body }) => {
+        expect(status).to.equal(200);
+        expect(body.status).to.equal(200);
+        expect(body.message).eql('The party already exists or your logo Url exists :-)');
+        done();
+      });
+  });
+});

--- a/server/tests/post-party.test.js
+++ b/server/tests/post-party.test.js
@@ -1,0 +1,146 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable prefer-destructuring */
+/* eslint-disable no-undef */
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import { app } from '../server';
+import { Parties } from '../controller/parties';
+
+chai.use(require('chai-like'));
+chai.use(require('chai-things'));
+
+// eslint-disable-next-line nso-unused-vars
+const should = chai.should();
+
+chai.use(chaiHttp);
+
+describe('POST /parties', () => {
+  it('Should add a new party ', (done) => {
+    const party = {
+      name: 'chama cha mapinduzi',
+      hqAddress: 'p.o bo 1234, dar-es-salaam',
+      logoUrl: '/img/ccm.png',
+      abbreviation: 'ccm',
+    };
+
+    chai
+      .request(app)
+      .post('/v1/parties')
+      .send(party)
+      .end((err, res) => {
+        res.should.have.status(201);
+        res.should.be.a('object');
+        done();
+      });
+  });
+  it('Should auto increment by 1', (done) => {
+    Parties.length = 0;
+    const party = {
+      name: 'civic union front',
+      hqAddress: 'p.o bo 1234, dar-es-salaam',
+      logoUrl: '/img/cuf.png',
+    };
+    const party2 = {
+      name: 'chama cha maendeleo na demokrasia',
+      hqAddress: 'p.o bo 1234, dar-es-salaam',
+      logoUrl: '/img/chadema.png',
+    };
+
+    chai
+      .request(app)
+      .post('/v1/parties')
+      .send(party)
+      .end((err, { body }) => {
+        body.should.have.status(201);
+        body.should.be.a('object');
+        body.should.have.property('data').be.an('array').that.contains.something.like({ id: 1 });
+      });
+    chai
+      .request(app)
+      .post('/v1/parties')
+      .send(party2)
+      .end((err, { body }) => {
+        body.should.have.status(201);
+        body.should.be.a('object');
+        body.should.have.property('data').be.an('array').that.contains.something.like({ id: 2 });
+        done();
+      });
+  });
+  it('Should not duplicate party', (done) => {
+    const party = {
+      name: 'civic union front',
+      hqAddress: 'p.o bo 1234, dar-es-salaam',
+      logoUrl: '/img/cuf.png',
+    };
+
+    chai
+      .request(app)
+      .post('/v1/parties')
+      .send(party)
+      .end((err, { body }) => {
+        body.should.have.status(200);
+        body.should.be.a('object');
+        body.should.have
+          .property('message')
+          .eql('The party already exists or your logo Url exists :-)');
+        done();
+      });
+  });
+
+  it('should not receive data against its entity specs', (done) => {
+    Parties.length = 0;
+    const party = {
+      name: 'chama cha mapinduzi',
+      hqAddress: 'p.o bo 1234, dar-es-salaam',
+    };
+    chai
+      .request(app)
+      .post('/v1/parties')
+      .send(party)
+      .end((err, { body }) => {
+        body.should.have.status(200);
+        body.should.be.a('object');
+        body.should.have
+          .property('message')
+          .eql('The object  has the properties name,hqAddress instead of having name,hqAddress,logoUrl');
+        done();
+      });
+  });
+
+  it('should not allow empty value', (done) => {
+    Parties.length = 0;
+    const party = {
+      name: '',
+      hqAddress: 'p.o bo 1234, dar-es-salaam',
+      logoUrl: '/ccm.png',
+    };
+    chai
+      .request(app)
+      .post('/v1/parties')
+      .send(party)
+      .end((err, { body }) => {
+        body.should.have.status(200);
+        body.should.be.a('object');
+        body.should.have.property('data').eql('name is empty');
+        done();
+      });
+  });
+  it('should not allow empty values', (done) => {
+    Parties.length = 0;
+    const party = {
+      name: '',
+      hqAddress: 'p.o bo 1234, dar-es-salaam',
+      logoUrl: '',
+    };
+    chai
+      .request(app)
+      .post('/v1/parties')
+      .send(party)
+      .end((err, { body }) => {
+        body.should.have.status(200);
+        body.should.be.a('object');
+        body.should.have.property('data').eql('name,logoUrl are empty');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
This PR enables the admin to store, retrieve, edit and delete parties from the database. Also through the introduction of JSON web token, it makes it easy for only the admin to edit the parties table on the database.

#### Description of Task to be completed?
The data sent by the client is checked for web tokens and if found it decrypted to get the data required to check if the user is an admin or not and if yes continues to make changes to the database. and if not the server will throw a 403 status that will forbid access to do anything with the server.

#### How should this be manually tested?
* Clone the repo to your local machine.
* When cloning is finished run
  ```
    `npm install`
  ```
* once the packages are installed, run
  ```
  `npm run start`
  ```
* send information to the `login` route using postman

#### Any background context you want to provide?
Before this PR the server was not able to do any login function nor generate JSON web token

#### What are the relevant pivotal tracker stories?
#164074806

#### Screenshots
![screenshot 29](https://user-images.githubusercontent.com/37019531/53115924-0cce1900-3550-11e9-8c64-6d8c4606f7d6.png)
