### PR TITLE
[feature #164134961] Created the result route and get back the results

### DIFF
--- a/server/controller/results.js
+++ b/server/controller/results.js
@@ -1,0 +1,15 @@
+import pool from '../model/connection';
+
+const result = (req, res) => {
+  const { id } = req.params;
+  const query = 'SELECT candidate,office,CAST(COUNT(*) AS Int) AS result FROM  vote WHERE office=$1 GROUP BY candidate,office';
+  pool.query(query, [id])
+    .then((results) => {
+      res.status(200).json({
+        status: 200,
+        data: results.rows,
+      });
+    });
+};
+
+export default result;

--- a/server/controller/results.js
+++ b/server/controller/results.js
@@ -5,10 +5,17 @@ const result = (req, res) => {
   const query = 'SELECT candidate,office,CAST(COUNT(*) AS Int) AS result FROM  vote WHERE office=$1 GROUP BY candidate,office';
   pool.query(query, [id])
     .then((results) => {
-      res.status(200).json({
-        status: 200,
-        data: results.rows,
-      });
+      if (results.rowCount > 0) {
+        res.status(200).json({
+          status: 200,
+          data: results.rows,
+        });
+      } else {
+        res.status(200).json({
+          status: 200,
+          message: 'There no results to display at the moment',
+        });
+      }
     });
 };
 

--- a/server/route/results.js
+++ b/server/route/results.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import result from '../controller/results';
+
+const router = express.Router();
+
+router.get('/:id/results', result);
+
+export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -7,6 +7,7 @@ import login from './route/login';
 import signupUser from './controller/signup';
 import jwtverifier from './middleware/verify';
 import isAdmin from './middleware/adminVerify';
+import result from './route/results';
 
 export const app = express();
 export const PORT = process.env.PORT || 3200;
@@ -17,6 +18,7 @@ app.use(bodyParser.urlencoded({
 
 app.use('/api/v1/parties/', jwtverifier, isAdmin, partiesRouter);
 app.use('/api/v1/offices/', jwtverifier, isAdmin, officesRouter);
+app.use('/api/v1/offices/', jwtverifier, result);
 app.use('/api/v1/login/', login);
 app.use('/api/v1/signup/', signupUser);
 app.use('/', defaultRoute);


### PR DESCRIPTION
#### What does this PR do?
This PR enables the user to view the result of the election. the router just checks for the office specified by the user and gives back the result for that particular route.

#### Description of Task to be completed?
The user sends a request to the server to get the results of a particular office and the server checks for the votes for the office and groups them together and count the data and give the results 

#### How should this be manually tested?
* Clone the repo to your local machine.
* When cloning is finished run
  ```
    `npm install`
  ```
* once the packages are installed, run
  ```
  `npm run start`
  ```
* Use the `sign up` route to signup to use the app
* login to the system to get a token.
* go to the `offices/:id/results`

#### Any background context you want to provide?
Before this PR the server was not able to allow a user to cast vote for any particular office

#### What are the relevant pivotal tracker stories?
#164134961

#### Screenshots
![screenshot 31](https://user-images.githubusercontent.com/37019531/53163478-e2736e80-35d6-11e9-96d2-685f9917d73a.png)