### PR TITLE
[feature #164136150] created the reset password route

### DIFF
--- a/server/controller/reset.js
+++ b/server/controller/reset.js
@@ -1,0 +1,24 @@
+import pool from '../model/connection';
+
+const reset = (req, res) => {
+  const { email } = req.body;
+  const verifyEmail = 'SELECT email FROM users WHERE email=$1';
+
+  pool.query(verifyEmail, [email])
+    .then((results) => {
+      if (results.rowCount === 1) {
+        res.status(200).json({
+          status: 200,
+          message: 'Check your email for password reset link',
+          email,
+        });
+      } else {
+        res.status(200).json({
+          status: 200,
+          message: 'Please use the email, you signed with',
+        });
+      }
+    });
+};
+
+export default reset;

--- a/server/route/reset.js
+++ b/server/route/reset.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import reset from '../controller/reset';
+
+const router = express.Router();
+
+router.post('/', reset);
+
+export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -7,6 +7,7 @@ import login from './route/login';
 import signupUser from './controller/signup';
 import jwtverifier from './middleware/verify';
 import isAdmin from './middleware/adminVerify';
+import reset from './route/reset';
 
 export const app = express();
 export const PORT = process.env.PORT || 3200;
@@ -17,6 +18,7 @@ app.use(bodyParser.urlencoded({
 
 app.use('/api/v1/parties/', jwtverifier, isAdmin, partiesRouter);
 app.use('/api/v1/offices/', jwtverifier, isAdmin, officesRouter);
+app.use('/api/v1/auth/reset/', reset);
 app.use('/api/v1/login/', login);
 app.use('/api/v1/signup/', signupUser);
 app.use('/', defaultRoute);


### PR DESCRIPTION
#### What does this PR do?
This PR enables the user to request a reset link from the server.

#### Description of Task to be completed?
The user has just to send the email used to sign up for an account and the server will verify it and respond appropriately.

#### How should this be manually tested?
* Clone the repo to your local machine.
* When cloning is finished run
  ```
    `npm install`
  ```
* once the packages are installed, run
  ```
  `npm run start`
  ```
* Send the email to `/auth/reset` route


#### Any background context you want to provide?
Before this PR the server was not able to allow a user to cast vote for any particular office

#### What are the relevant pivotal tracker stories?
#164136150

#### Screenshots
![screenshot 32](https://user-images.githubusercontent.com/37019531/53166542-40578480-35de-11e9-8b16-cd91dc9cdcd1.png)
